### PR TITLE
add a pre-commit to the repo for clippy/fmt ease

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
+    -   id: clippy


### PR DESCRIPTION
allows users to install the pre-commit-rust hooks to run clippy and fmt.